### PR TITLE
Get `student-financial-aid` running alongside the `sfa-client`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,16 @@ cd ./src/web
 npm install
 npm run start
 ```
+
+### Development with `sfa-client` back-end
+
+1. Clone the `sfa-client` repo into the same root directory as this project via `git clone git@github.com:icefoganalytics/sfa-client.git`
+
+2. You should now be able to see both repositories side by side.
+   i.e. `ls` should output `sfa-client` and `student-financial-aid`
+
+3. Boot the `sfa-client` back-end using `cd ./sfa-client && API_PORT=3100 dev up` in its repo.
+
+4. In a new tab, boot the local api service via `cd ./student-financial-aid/src/api && npm run start`
+
+5. In a new tab, boot the local web service via `cd ./student-financial-aid/src/web && npm run start`

--- a/README.md
+++ b/README.md
@@ -50,11 +50,10 @@ npm run start
 
 1. Clone the `sfa-client` repo into the same root directory as this project via `git clone git@github.com:icefoganalytics/sfa-client.git`
 
-2. You should now be able to see both repositories side by side.
-   i.e. `ls` should output `sfa-client` and `student-financial-aid`
+   Directory structure should look like: - my-organization - sfa-client - student-financial-aid
 
-3. Boot the `sfa-client` back-end using `cd ./sfa-client && API_PORT=3100 dev up` in its repo.
+2. Boot the `sfa-client` back-end using `cd ./sfa-client && API_PORT=3100 dev up` in its repo.
 
-4. In a new tab, boot the local api service via `cd ./student-financial-aid/src/api && npm run start`
+3. In a new tab, from the `my-originalization` directory, boot the `sfa-client` api service via `cd ./student-financial-aid/src/api && npm run start`
 
-5. In a new tab, boot the local web service via `cd ./student-financial-aid/src/web && npm run start`
+4. In a new tab, from the `my-originalization` directory, boot the `sfa-client` web service via `cd ./student-financial-aid/src/web && npm run start`


### PR DESCRIPTION
Depends on:
- https://github.com/icefoganalytics/sfa-client/issues/8

Fixes https://github.com/icefoganalytics/student-financial-aid/issues/3

# Context

Figure out how to boot to boot the sub-service `student-financial-aid` with the backing service `sfa-client`.
Add some instructions for repeatability.
Investigate a docker compose setup that boots both at once.

## Implementation

- `sfa-client` needs to run the database service, and the api service with port 3100.
- `student-financial-aid` needs to run its api service on port 3000, and its web service on port 8080.

# Testing Instructions

Development with `sfa-client` back-end

1. Clone the `sfa-client` repo into the same root directory as this project via `git clone git@github.com:icefoganalytics/sfa-client.git`

   Directory structure should look like: - my-organization - sfa-client - student-financial-aid

2. Boot the `sfa-client` back-end using `cd ./sfa-client && API_PORT=3100 dev up` in its repo.

3. In a new tab, from the `my-originalization` directory, boot the `sfa-client` api service via `cd ./student-financial-aid/src/api && npm run start`

4. In a new tab, from the `my-originalization` directory, boot the `sfa-client` web service via `cd ./student-financial-aid/src/web && npm run start`