### PR TITLE
Refactor: Rebuild the getNext Navigation Function So It Doesn’t Block

### DIFF
--- a/src/web/src/modules/draft/store/index.ts
+++ b/src/web/src/modules/draft/store/index.ts
@@ -24,7 +24,7 @@ export const useDraftStore = defineStore("draft", {
     requiredDocuments: new Array<any>(),
   }),
   getters: {
-    relevantSections(): any[] {
+    relevantSections(): { name: string; uri: string; is_complete?: boolean; disabled?: boolean }[] {
       let app = this.application;
 
       if (!app) return [];
@@ -1003,19 +1003,19 @@ export const useDraftStore = defineStore("draft", {
       return "";
     },
 
-    getNext(current: string): string {
-      if (!this.application) return "";
+    getNext(currentSectionName: string): string {
+      const currentIndex = this.relevantSections.findIndex((s) => s.name == currentSectionName);
+      if (currentIndex === -1) throw new Error("Could not find passed section.")
 
-      for (let i = 0; i < this.relevantSections.length; i++) {
-        let sect = this.relevantSections[i];
-        if (current == sect.name) {
-          let next = this.relevantSections[i + 1];
-          if (next.disabled) return sect.uri;
+      const currentSection = this.relevantSections[currentIndex]
+      const nextSection = this.relevantSections[currentIndex + 1]
+      const firstSection = this.relevantSections[0]
 
-          return this.relevantSections[i + 1].uri;
-        }
-      }
-      return "";
+      if (firstSection === undefined) return ""
+      if (nextSection === undefined) return firstSection.uri
+      if (nextSection.disabled) return firstSection.uri
+
+      return nextSection.uri
     },
 
     getPrevious(current: string): string {


### PR DESCRIPTION
Relates to https://github.com/ytgov/sfa-client/pull/108

# Context

When attempting to complete a funding request application, the "Save and next" button kept not working for me.

# Implementation

Fix "getNext" navigation function.
Use better typing in relevantSections
Use standard find methods instead of complex loop.

# Note
Note, it would probably be better to have the "getNext" function return the next section so that the "Agree and Next" button could be disabled if the next section was disabled. I opted for a "loop around" pattern instead of the "just go nowhere and look broken approach".

# Testing Instructions

1. In the `sfa-client` repo boot the back-end via `API_PORT=3100 dev up`
2. In the `student-financial-aid` repo boot the back-end via `cd src/api && npm run start`
3. In the `student-financial-aid` repo boot the front-end via `cd src/web && npm run start`
4. Go to `http://localhost:8080` and log in.
5. Either edit an existing "In Progress" application or create a new one.
6. Try out the "aggree and next" buttons and see if they work better than before.